### PR TITLE
chore: update to java 21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'co.devskills'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = '21'
 
 bootJar {
     enabled = false


### PR DESCRIPTION
depends on deploying new devcontainer updates + deploying publish-test-results update